### PR TITLE
Allow to specify different config file for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: groovy

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Other optional properties are
   verbose //Default => false
   quiet //Default => false
   includeTestSourceDirectory //Default => false
+  testConfigLocation //Separate configuration file to be used for test sources
   inputEncoding //Default => UTF-8
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Scala Style Gradle Plugin
 
+[![Build Status](https://travis-ci.org/alenkacz/gradle-scalastyle-plugin.svg?branch=master)](https://travis-ci.org/alenkacz/gradle-scalastyle-plugin)
+
 ### Instructions
 
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,9 @@ subprojects {
 
       compile "org.scalastyle:scalastyle_${versions.scalaDist}:${versions.scalaStyle}"
       testCompile 'junit:junit:${versions.junit}'
+      testCompile ('org.spockframework:spock-core:1.0-groovy-2.3') {
+          exclude group:'org.codehaus.groovy'
+      }
   }
 
   compileGroovy.dependsOn(compileScala)

--- a/gradle-scalastyle-plugin_2.10/src/main/groovy/org/github/ngbinh/scalastyle/ScalaStyleTask.groovy
+++ b/gradle-scalastyle-plugin_2.10/src/main/groovy/org/github/ngbinh/scalastyle/ScalaStyleTask.groovy
@@ -36,6 +36,7 @@ import com.typesafe.config.Config
 class ScalaStyleTask extends SourceTask {
     File buildDirectory
     String configLocation
+    String testConfigLocation
     String outputFile
     String outputEncoding = "UTF-8"
     Boolean failOnViolation = true
@@ -63,11 +64,16 @@ class ScalaStyleTask extends SourceTask {
                 def configuration = ScalastyleConfiguration.readFromXml(configLocation)
                 def fileToProcess = scalaStyleUtils.getFilesToProcess(source.getFiles().toList(), testSourceDir.getFiles().toList(), inputEncoding, includeTestSourceDirectory)
                 def messages = new ScalastyleChecker().checkFiles(configuration, fileToProcess)
+
+                def testConfiguration = ScalastyleConfiguration.readFromXml(testConfigLocation)
+                if (testConfiguration != null) {
+                    def testFilesToProcess = scalaStyleUtils.getFilesToProcess(source.getFiles().toList(), testSourceDir.getFiles().toList(), inputEncoding, includeTestSourceDirectory)
+                    messages.addAll(new ScalastyleChecker().checkFiles(testConfiguration, testFilesToProcess))
+                }
+
                 def config = ConfigFactory.load()
 
                 def outputResult = new TextOutput(config, verbose, quiet).output(messages)
-
-                outputResult.println()
 
                 project.getLogger().debug("Saving to outputFile={}", project.file(outputFile).getCanonicalPath());
                 XmlOutput.save(config, outputFile, outputEncoding, messages)
@@ -118,6 +124,10 @@ class ScalaStyleTask extends SourceTask {
             testSourceDir = project.fileTree(project.projectDir.absolutePath + "/" + testSource)
         }
 
+        if (testConfigLocation != null && !new File(testConfigLocation).exists()) {
+            throw new Exception("testConfigLocation " + testConfigLocation + " does not exist")
+        }
+
         if (!new File(configLocation).exists()) {
             throw new Exception("configLocation " + configLocation + " does not exist")
         }
@@ -137,6 +147,7 @@ class ScalaStyleTask extends SourceTask {
 
         if (verbose) {
             project.getLogger().info("configLocation: {}", configLocation)
+            project.getLogger().info("testConfigLocation: {}", testConfigLocation)
             project.getLogger().info("buildDirectory: {}", buildDirectory)
             project.getLogger().info("outputFile: {}", outputFile)
             project.getLogger().info("outputEncoding: {}", outputEncoding)

--- a/gradle-scalastyle-plugin_2.10/src/main/scala/org/github/ngbinh/scalastyle/ScalaStyleUtils.scala
+++ b/gradle-scalastyle-plugin_2.10/src/main/scala/org/github/ngbinh/scalastyle/ScalaStyleUtils.scala
@@ -39,6 +39,10 @@ class ScalaStyleUtils {
     sd ::: tsd
   }
 
+  def getTestFilesToProcess(testFiles: jList[File], inputEncoding: String, includeTestSourceDirectory: Boolean): List[FileSpec] = {
+    getFiles("testFiles", asScalaBufferConverter(testFiles).asScala.toList, inputEncoding)
+  }
+
   def getFiles(name: String, file: List[File], encoding: String) = {
       Directory.getFiles(Option[String](encoding), file)
   }

--- a/gradle-scalastyle-plugin_2.10/src/test/groovy/ScalaStylePluginTest.groovy
+++ b/gradle-scalastyle-plugin_2.10/src/test/groovy/ScalaStylePluginTest.groovy
@@ -1,0 +1,16 @@
+import org.github.ngbinh.scalastyle.ScalaStyleTask
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Test
+import spock.lang.Specification
+
+public class ScalaStylePluginTest extends Specification {
+    def "add tasks to the project"() {
+        when:
+        Project project = ProjectBuilder.builder().build()
+        project.plugins.apply "scalaStyle"
+
+        then:
+        project.tasks.scalaStyle instanceof ScalaStyleTask
+    }
+}

--- a/gradle-scalastyle-plugin_2.11/src/main/scala/org/github/ngbinh/scalastyle/ScalaStyleUtils.scala
+++ b/gradle-scalastyle-plugin_2.11/src/main/scala/org/github/ngbinh/scalastyle/ScalaStyleUtils.scala
@@ -37,6 +37,10 @@ class ScalaStyleUtils {
     sd ::: tsd
   }
 
+  def getTestFilesToProcess(testFiles: jList[File], inputEncoding: String, includeTestSourceDirectory: Boolean): List[FileSpec] = {
+    getFiles("testFiles", asScalaBufferConverter(testFiles).asScala.toList, inputEncoding)
+  }
+
   def getFiles(name: String, file: List[File], encoding: String) = {
       Directory.getFiles(Option[String](encoding), file)
   }


### PR DESCRIPTION
SBT plugin allows this and it might be useful since some rules might
make sense in code but not in tests (e.g. rule that looks for repeated
strings)