### PR TITLE
Fix for using testConfiguration

### DIFF
--- a/gradle-scalastyle-plugin_2.10/src/main/scala/org/github/ngbinh/scalastyle/ScalaStyleUtils.scala
+++ b/gradle-scalastyle-plugin_2.10/src/main/scala/org/github/ngbinh/scalastyle/ScalaStyleUtils.scala
@@ -51,8 +51,8 @@ class ScalaStyleUtils {
 
   def isDirectory(file: File) = file != null && file.exists() && file.isDirectory
 
-  def checkFiles(configuration: ScalastyleConfiguration, files: List[FileSpec]): List[Message[FileSpec]] = {
-    new ScalastyleChecker(Some(this.getClass().getClassLoader())).checkFiles(configuration, files)
+  def checkFiles(configuration: ScalastyleConfiguration, files: List[FileSpec]): jList[Message[FileSpec]] = {
+    new ScalastyleChecker(Some(this.getClass().getClassLoader())).checkFiles(configuration, files).toBuffer.asJava
   }
 
   def configFactory(): Config = {

--- a/gradle-scalastyle-plugin_2.11/src/main/scala/org/github/ngbinh/scalastyle/ScalaStyleUtils.scala
+++ b/gradle-scalastyle-plugin_2.11/src/main/scala/org/github/ngbinh/scalastyle/ScalaStyleUtils.scala
@@ -51,8 +51,8 @@ class ScalaStyleUtils {
 
   def isDirectory(file: File) = file != null && file.exists() && file.isDirectory
 
-  def checkFiles(configuration: ScalastyleConfiguration, files: List[FileSpec]): List[Message[FileSpec]] = {
-    new ScalastyleChecker(Some(this.getClass().getClassLoader())).checkFiles(configuration, files)
+  def checkFiles(configuration: ScalastyleConfiguration, files: List[FileSpec]): jList[Message[FileSpec]] = {
+    new ScalastyleChecker(Some(this.getClass().getClassLoader())).checkFiles(configuration, files).toBuffer.asJava
   }
 
   def configFactory(): Config = {

--- a/gradle-scalastyle-plugin_2.12/src/main/groovy/org/github/ngbinh/scalastyle/ScalaStyleTask.groovy
+++ b/gradle-scalastyle-plugin_2.12/src/main/groovy/org/github/ngbinh/scalastyle/ScalaStyleTask.groovy
@@ -20,12 +20,9 @@ package org.github.ngbinh.scalastyle
 import org.gradle.api.file.FileTree
 import org.gradle.api.tasks.SourceTask
 import org.gradle.api.tasks.TaskAction
-import org.scalastyle.ScalastyleChecker
 import org.scalastyle.ScalastyleConfiguration
 import org.scalastyle.TextOutput
 import org.scalastyle.XmlOutput
-import com.typesafe.config.ConfigFactory
-import com.typesafe.config.Config
 
 /**
  * @author Binh Nguyen
@@ -68,7 +65,7 @@ class ScalaStyleTask extends SourceTask {
                 if (testConfigLocation != null) {
                   def testConfiguration = ScalastyleConfiguration.readFromXml(testConfigLocation)
                   if (testConfiguration != null) {
-                      def testFilesToProcess = scalaStyleUtils.getTestFilesToProcess(source.getFiles().toList(), testSourceDir.getFiles().toList(), inputEncoding, includeTestSourceDirectory)
+                      def testFilesToProcess = scalaStyleUtils.getTestFilesToProcess(testSourceDir.getFiles().toList(), inputEncoding)
                       messages.addAll(scalaStyleUtils.checkFiles(testConfiguration, testFilesToProcess))
                   }
                 }
@@ -120,7 +117,7 @@ class ScalaStyleTask extends SourceTask {
             throw new Exception("Specify Scala source set")
         }
 
-        if (includeTestSourceDirectory && testSource == null) {
+        if (testSource == null) {
             testSourceDir = project.fileTree(project.projectDir.absolutePath + "/src/test/scala")
         } else {
             testSourceDir = project.fileTree(project.projectDir.absolutePath + "/" + testSource)

--- a/gradle-scalastyle-plugin_2.12/src/main/scala/org/github/ngbinh/scalastyle/ScalaStyleUtils.scala
+++ b/gradle-scalastyle-plugin_2.12/src/main/scala/org/github/ngbinh/scalastyle/ScalaStyleUtils.scala
@@ -25,6 +25,7 @@ import com.typesafe.config.ConfigFactory
 import com.typesafe.config.Config
 import java.io.File
 import java.util.{List => jList}
+
 import scala.collection.JavaConverters._
 
 /**
@@ -51,8 +52,8 @@ class ScalaStyleUtils {
 
   def isDirectory(file: File) = file != null && file.exists() && file.isDirectory
 
-  def checkFiles(configuration: ScalastyleConfiguration, files: List[FileSpec]): List[Message[FileSpec]] = {
-    new ScalastyleChecker(Some(this.getClass().getClassLoader())).checkFiles(configuration, files)
+  def checkFiles(configuration: ScalastyleConfiguration, files: List[FileSpec]): jList[Message[FileSpec]] = {
+    new ScalastyleChecker(Some(this.getClass().getClassLoader())).checkFiles(configuration, files).toBuffer.asJava
   }
 
   def configFactory(): Config = {

--- a/gradle-scalastyle-plugin_2.12/src/main/scala/org/github/ngbinh/scalastyle/ScalaStyleUtils.scala
+++ b/gradle-scalastyle-plugin_2.12/src/main/scala/org/github/ngbinh/scalastyle/ScalaStyleUtils.scala
@@ -41,7 +41,7 @@ class ScalaStyleUtils {
     sd ::: tsd
   }
 
-  def getTestFilesToProcess(testFiles: jList[File], inputEncoding: String, includeTestSourceDirectory: Boolean): List[FileSpec] = {
+  def getTestFilesToProcess(testFiles: jList[File], inputEncoding: String): List[FileSpec] = {
     getFiles("testFiles", asScalaBufferConverter(testFiles).asScala.toList, inputEncoding)
   }
 


### PR DESCRIPTION
This includes two fixes:

* Fix incorrect invocation of getTestFilesToProcess for 2.12  …
PR #28 (which fixes #22) was fixed the issue for the code in 2.10 and 2.11,
but when 2.12 was added in 94d5ecc the fix
wasn't present.

* checkFiles was returning a Scala List, and ScalaStyleTask was attempting
to call addAll on this, which isn't valid. This commit changes the method
to return a mutable Java list, which works.