### PR TITLE
Changes log level to info for no warnings/errors messages

### DIFF
--- a/gradle-scalastyle-plugin_source/src/main/groovy/org/github/ngbinh/scalastyle/ScalaStyleTask.groovy
+++ b/gradle-scalastyle-plugin_source/src/main/groovy/org/github/ngbinh/scalastyle/ScalaStyleTask.groovy
@@ -99,8 +99,16 @@ class ScalaStyleTask extends SourceTask {
                 def stopMs = System.currentTimeMillis()
                 if (!quiet) {
                     logger.info("Processed {} file(s)", outputResult.files())
-                    logger.warn("Found {} warnings", outputResult.warnings())
-                    logger.error("Found {} errors", outputResult.errors())
+                    if (outputResult.warnings() > 0) {
+                        logger.warn("Found {} warnings", outputResult.warnings())
+                    } else {
+                        logger.info("Found 0 warnings")
+                    }
+                    if (outputResult.errors() > 0) {
+                        logger.error("Found {} errors", outputResult.errors())
+                    } else {
+                        logger.info("Found 0 errors")   
+                    }
                     logger.info("Finished in {} ms", stopMs - startMs)
                 }
 


### PR DESCRIPTION
This PR changes the log level at which messages about the number of warnings/errors are displayed when there are none.

The reason for that change is to get rid of misleading colouring over those messages.